### PR TITLE
Cumulated changes from philippseith/signalr

### DIFF
--- a/signalr-go-server/pkg/signalr/clientproxy.go
+++ b/signalr-go-server/pkg/signalr/clientproxy.go
@@ -1,5 +1,6 @@
 package signalr
 
+//ClientProxy allows the hub to send messages to one or more of its clients
 type ClientProxy interface {
 	Send(target string, args ...interface{})
 }

--- a/signalr-go-server/pkg/signalr/clientproxy.go
+++ b/signalr-go-server/pkg/signalr/clientproxy.go
@@ -1,6 +1,6 @@
 package signalr
 
-//ClientProxy allows the hub to send messages to one or more of its clients
+// ClientProxy allows the hub to send messages to one or more of its clients
 type ClientProxy interface {
 	Send(target string, args ...interface{})
 }

--- a/signalr-go-server/pkg/signalr/connection.go
+++ b/signalr-go-server/pkg/signalr/connection.go
@@ -2,7 +2,7 @@ package signalr
 
 import "io"
 
-//Connection describes a connection between signalR client and Server
+// Connection describes a connection between signalR client and Server
 type Connection interface {
 	io.Reader
 	io.Writer

--- a/signalr-go-server/pkg/signalr/groupmanager.go
+++ b/signalr-go-server/pkg/signalr/groupmanager.go
@@ -1,5 +1,6 @@
 package signalr
 
+//GroupManager manages the client groups of the hub
 type GroupManager interface {
 	AddToGroup(groupName string, connectionID string)
 	RemoveFromGroup(groupName string, connectionID string)

--- a/signalr-go-server/pkg/signalr/groupmanager.go
+++ b/signalr-go-server/pkg/signalr/groupmanager.go
@@ -1,6 +1,6 @@
 package signalr
 
-//GroupManager manages the client groups of the hub
+// GroupManager manages the client groups of the hub
 type GroupManager interface {
 	AddToGroup(groupName string, connectionID string)
 	RemoveFromGroup(groupName string, connectionID string)

--- a/signalr-go-server/pkg/signalr/hub.go
+++ b/signalr-go-server/pkg/signalr/hub.go
@@ -1,27 +1,34 @@
 package signalr
 
+// HubInterface is a hubs interface
 type HubInterface interface {
 	Initialize(hubContext HubContext)
 	OnConnected(connectionID string)
 	OnDisconnected(connectionID string)
 }
 
+// Hub is a base class for hubs
 type Hub struct {
 	context HubContext
 }
 
+// Initialize initializes a hub with a HubContext
 func (h *Hub) Initialize(ctx HubContext) {
 	h.context = ctx
 }
 
+// Clients returns the clients of this hub
 func (h *Hub) Clients() HubClients {
 	return h.context.Clients()
 }
 
+// Groups returns the client groups of this hub
 func (h *Hub) Groups() GroupManager {
 	return h.context.Groups()
 }
 
+// OnConnected is called when the hub is connected
 func (h *Hub) OnConnected(string) {}
 
+//OnDisconnected is called when the hub is disconnected
 func (h *Hub) OnDisconnected(string) {}

--- a/signalr-go-server/pkg/signalr/hub.go
+++ b/signalr-go-server/pkg/signalr/hub.go
@@ -30,5 +30,5 @@ func (h *Hub) Groups() GroupManager {
 // OnConnected is called when the hub is connected
 func (h *Hub) OnConnected(string) {}
 
-//OnDisconnected is called when the hub is disconnected
+// OnDisconnected is called when the hub is disconnected
 func (h *Hub) OnDisconnected(string) {}

--- a/signalr-go-server/pkg/signalr/hubclients.go
+++ b/signalr-go-server/pkg/signalr/hubclients.go
@@ -1,5 +1,6 @@
 package signalr
 
+//HubClients gives the hub access to various client groups
 type HubClients interface {
 	All() ClientProxy
 	Client(connectionID string) ClientProxy

--- a/signalr-go-server/pkg/signalr/hubclients.go
+++ b/signalr-go-server/pkg/signalr/hubclients.go
@@ -1,6 +1,9 @@
 package signalr
 
-//HubClients gives the hub access to various client groups
+// HubClients gives the hub access to various client groups
+// All() gets a ClientProxy that can be used to invoke methods on all clients connected to the hub
+// Client() gets a ClientProxy that can be used to invoke methods on the specified client connection
+// Group() gets a ClientProxy that can be used to invoke methods on all connections in the specified group
 type HubClients interface {
 	All() ClientProxy
 	Client(connectionID string) ClientProxy

--- a/signalr-go-server/pkg/signalr/hubconnection.go
+++ b/signalr-go-server/pkg/signalr/hubconnection.go
@@ -2,6 +2,7 @@ package signalr
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"sync/atomic"
 )
@@ -54,7 +55,9 @@ func (c *defaultHubConnection) Close(error string) {
 		Error:          error,
 		AllowReconnect: true,
 	}
-	c.Protocol.WriteMessage(closeMessage, c.Connection)
+	if err := c.Protocol.WriteMessage(closeMessage, c.Connection); err != nil {
+		fmt.Printf("cannot close connection %v: %v", c.GetConnectionID(), err)
+	}
 }
 
 func (c *defaultHubConnection) GetConnectionID() string {
@@ -68,7 +71,9 @@ func (c *defaultHubConnection) SendInvocation(target string, args []interface{})
 		Arguments: args,
 	}
 
-	c.Protocol.WriteMessage(invocationMessage, c.Connection)
+	if err := c.Protocol.WriteMessage(invocationMessage, c.Connection); err != nil {
+		fmt.Printf("cannot send invocation %v %v over connection %v: %v", target, args, c.GetConnectionID(), err)
+	}
 }
 
 func (c *defaultHubConnection) Ping() {
@@ -76,7 +81,9 @@ func (c *defaultHubConnection) Ping() {
 		Type: 6,
 	}
 
-	c.Protocol.WriteMessage(pingMessage, c.Connection)
+	if err := c.Protocol.WriteMessage(pingMessage, c.Connection); err != nil {
+		fmt.Printf("cannot ping over connection %v: %v", c.GetConnectionID(), err)
+	}
 }
 
 func (c *defaultHubConnection) Receive() (interface{}, error) {
@@ -107,7 +114,9 @@ func (c *defaultHubConnection) Completion(id string, result interface{}, error s
 		Error:        error,
 	}
 
-	c.Protocol.WriteMessage(completionMessage, c.Connection)
+	if err := c.Protocol.WriteMessage(completionMessage, c.Connection); err != nil {
+		fmt.Printf("cannot send completion for invocation %v over connection %v: %v", id, c.GetConnectionID(), err)
+	}
 }
 
 func (c *defaultHubConnection) StreamItem(id string, item interface{}) {
@@ -117,5 +126,7 @@ func (c *defaultHubConnection) StreamItem(id string, item interface{}) {
 		Item:         item,
 	}
 
-	c.Protocol.WriteMessage(streamItemMessage, c.Connection)
+	if err := c.Protocol.WriteMessage(streamItemMessage, c.Connection); err != nil {
+		fmt.Printf("cannot send stream item for invocation %v over connection %v: %v", id, c.GetConnectionID(), err)
+	}
 }

--- a/signalr-go-server/pkg/signalr/hubconnection.go
+++ b/signalr-go-server/pkg/signalr/hubconnection.go
@@ -87,10 +87,10 @@ func (c *defaultHubConnection) Receive() (interface{}, error) {
 			// Partial message, need more data
 			// ReadMessage read data out of the buf, so its gone there: refill
 			buf.Write(data[:n])
-			if n, err = c.Connection.Read(data); err != nil {
-				return nil, err
-			} else {
+			if n, err = c.Connection.Read(data); err == nil {
 				buf.Write(data[:n])
+			} else {
+				return nil, err
 			}
 		} else {
 			return message, err

--- a/signalr-go-server/pkg/signalr/hubcontext.go
+++ b/signalr-go-server/pkg/signalr/hubcontext.go
@@ -1,5 +1,6 @@
 package signalr
 
+//HubContext holds the clients and groups connected to the hub
 type HubContext interface {
 	Clients() HubClients
 	Groups() GroupManager

--- a/signalr-go-server/pkg/signalr/hubcontext.go
+++ b/signalr-go-server/pkg/signalr/hubcontext.go
@@ -1,6 +1,8 @@
 package signalr
 
-//HubContext holds the clients and groups connected to the hub
+// HubContext is a context abstraction for a hub
+// Clients() gets a HubClients that can be used to invoke methods on clients connected to the hub
+// Groups() gets a GroupManager that can be used to add and remove connections to named groups
 type HubContext interface {
 	Clients() HubClients
 	Groups() GroupManager

--- a/signalr-go-server/pkg/signalr/hublifetimemanager.go
+++ b/signalr-go-server/pkg/signalr/hublifetimemanager.go
@@ -2,7 +2,14 @@ package signalr
 
 import "sync"
 
-//HubLifetimeManager manages the lifetime of a hub
+// HubLifetimeManager is a lifetime manager abstraction for hub instances
+// OnConnected() is called when a connection is started
+// OnDisconnected() is called when a connection is finished
+// InvokeAll() sends an invocation message to all hub connections
+// InvokeClient() sends an invocation message to a specified hub connection
+// InvokeGroup() sends an invocation message to a specified group of hub connections
+// AddToGroup() adds a connection to the specified group
+// RemoveFromGroup() removes a connection from the specified group
 type HubLifetimeManager interface {
 	OnConnected(conn hubConnection)
 	OnDisconnected(conn hubConnection)

--- a/signalr-go-server/pkg/signalr/hublifetimemanager.go
+++ b/signalr-go-server/pkg/signalr/hublifetimemanager.go
@@ -2,6 +2,7 @@ package signalr
 
 import "sync"
 
+//HubLifetimeManager manages the lifetime of a hub
 type HubLifetimeManager interface {
 	OnConnected(conn hubConnection)
 	OnDisconnected(conn hubConnection)

--- a/signalr-go-server/pkg/signalr/invocation_test.go
+++ b/signalr-go-server/pkg/signalr/invocation_test.go
@@ -213,4 +213,20 @@ var _ = Describe("Invocation", func() {
 			})
 		})
 	})
+
+	Describe("Missing method invocation", func() {
+		conn := connect(&invocationHub{})
+		Context("When a missing server method invoked by the client", func() {
+			It("should return an error", func() {
+				_, err := conn.clientSend(`{"type":1,"invocationId": "0000","target":"missing"}`)
+				Expect(err).To(BeNil())
+				recv := (<-conn.received).(completionMessage)
+				Expect(recv).NotTo(BeNil())
+				Expect(recv.InvocationID).To(Equal("0000"))
+				Expect(recv.Result).To(BeNil())
+				Expect(recv.Error).NotTo(BeNil())
+				Expect(len(recv.Error)).To(BeNumerically(">", 0))
+			})
+		})
+	})
 })

--- a/signalr-go-server/pkg/signalr/jsonhubprotocol.go
+++ b/signalr-go-server/pkg/signalr/jsonhubprotocol.go
@@ -3,6 +3,7 @@ package signalr
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -26,12 +27,9 @@ func (j *jsonHubProtocol) UnmarshalArgument(argument interface{}, value interfac
 func (j *jsonHubProtocol) ReadMessage(buf *bytes.Buffer) (interface{}, bool, error) {
 	data, err := parseTextMessageFormat(buf)
 	switch {
-	case err == io.EOF:
+	case errors.Is(err, io.EOF):
 		return nil, false, err
 	case err != nil:
-		return nil, true, err
-	}
-	if err != nil {
 		return nil, true, err
 	}
 

--- a/signalr-go-server/pkg/signalr/jsonhubprotocol.go
+++ b/signalr-go-server/pkg/signalr/jsonhubprotocol.go
@@ -7,7 +7,7 @@ import (
 	"io"
 )
 
-type JsonHubProtocol struct {
+type jsonHubProtocol struct {
 }
 
 // Protocol specific message for correct unmarshaling of Arguments
@@ -19,11 +19,11 @@ type jsonInvocationMessage struct {
 	StreamIds    []string          `json:"streamIds,omitempty"`
 }
 
-func (j *JsonHubProtocol) UnmarshalArgument(argument interface{}, value interface{}) error {
+func (j *jsonHubProtocol) UnmarshalArgument(argument interface{}, value interface{}) error {
 	return json.Unmarshal(argument.(json.RawMessage), value)
 }
 
-func (j *JsonHubProtocol) ReadMessage(buf *bytes.Buffer) (interface{}, bool, error) {
+func (j *jsonHubProtocol) ReadMessage(buf *bytes.Buffer) (interface{}, bool, error) {
 	data, err := parseTextMessageFormat(buf)
 	switch {
 	case err == io.EOF:
@@ -86,7 +86,7 @@ func parseTextMessageFormat(buf *bytes.Buffer) ([]byte, error) {
 	return data[0 : len(data)-1], err
 }
 
-func (j *JsonHubProtocol) WriteMessage(message interface{}, writer io.Writer) error {
+func (j *jsonHubProtocol) WriteMessage(message interface{}, writer io.Writer) error {
 
 	// TODO: Reduce the amount of copies
 

--- a/signalr-go-server/pkg/signalr/jsonhubprotocol.go
+++ b/signalr-go-server/pkg/signalr/jsonhubprotocol.go
@@ -8,7 +8,7 @@ import (
 	"io"
 )
 
-type jsonHubProtocol struct {
+type JsonHubProtocol struct {
 }
 
 // Protocol specific message for correct unmarshaling of Arguments
@@ -20,11 +20,11 @@ type jsonInvocationMessage struct {
 	StreamIds    []string          `json:"streamIds,omitempty"`
 }
 
-func (j *jsonHubProtocol) UnmarshalArgument(argument interface{}, value interface{}) error {
+func (j *JsonHubProtocol) UnmarshalArgument(argument interface{}, value interface{}) error {
 	return json.Unmarshal(argument.(json.RawMessage), value)
 }
 
-func (j *jsonHubProtocol) ReadMessage(buf *bytes.Buffer) (interface{}, bool, error) {
+func (j *JsonHubProtocol) ReadMessage(buf *bytes.Buffer) (interface{}, bool, error) {
 	data, err := parseTextMessageFormat(buf)
 	switch {
 	case errors.Is(err, io.EOF):
@@ -84,7 +84,7 @@ func parseTextMessageFormat(buf *bytes.Buffer) ([]byte, error) {
 	return data[0 : len(data)-1], err
 }
 
-func (j *jsonHubProtocol) WriteMessage(message interface{}, writer io.Writer) error {
+func (j *JsonHubProtocol) WriteMessage(message interface{}, writer io.Writer) error {
 
 	// TODO: Reduce the amount of copies
 

--- a/signalr-go-server/pkg/signalr/server.go
+++ b/signalr-go-server/pkg/signalr/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 )
 
+// Server is a SignalR server for one type of hub
 type Server struct {
 	hub               HubInterface
 	lifetimeManager   HubLifetimeManager
@@ -18,6 +19,7 @@ type Server struct {
 	groupManager      GroupManager
 }
 
+// NewServer creates a new server for one type of hub
 func NewServer(hub HubInterface) *Server {
 	lifetimeManager := defaultHubLifetimeManager{}
 	return &Server{
@@ -33,6 +35,7 @@ func NewServer(hub HubInterface) *Server {
 	}
 }
 
+// Run runs the server on one connection. The same server might be run on different connections in parallel
 func (s *Server) Run(conn Connection) {
 	if protocol, err := processHandshake(conn); err != nil {
 		fmt.Println(err)

--- a/signalr-go-server/pkg/signalr/server.go
+++ b/signalr-go-server/pkg/signalr/server.go
@@ -289,7 +289,7 @@ func processHandshake(conn Connection) (HubProtocol, error) {
 }
 
 var protocolMap = map[string]HubProtocol{
-	"json": &jsonHubProtocol{},
+	"json": &JsonHubProtocol{},
 }
 
 type availableTransport struct {

--- a/signalr-go-server/pkg/signalr/signalr_suite_test.go
+++ b/signalr-go-server/pkg/signalr/signalr_suite_test.go
@@ -13,7 +13,7 @@ func TestSignalr(t *testing.T) {
 }
 
 func connect(hubProto HubInterface) *testingConnection {
-	server := NewServer(hubProto)
+	server := newServer(hubProto)
 	conn := newTestingConnection()
 	go server.messageLoop(conn)
 	return conn

--- a/signalr-go-server/pkg/signalr/testingconnection_test.go
+++ b/signalr-go-server/pkg/signalr/testingconnection_test.go
@@ -3,6 +3,8 @@ package signalr
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"github.com/onsi/ginkgo"
 	"io"
 )
 
@@ -37,7 +39,9 @@ func newTestingConnection() *testingConnection {
 	}
 	// Send initial Handshake
 	go func() {
-		conn.clientSend(`{"protocol": "json","version": 1}`)
+		if _, err := conn.clientSend(`{"protocol": "json","version": 1}`); err != nil {
+			ginkgo.Fail(fmt.Sprint(err))
+		}
 	}()
 	conn.received = make(chan interface{}, 20)
 	go func() {

--- a/signalr-go-server/pkg/signalr/testingconnection_test.go
+++ b/signalr-go-server/pkg/signalr/testingconnection_test.go
@@ -14,7 +14,7 @@ type testingConnection struct {
 	received  chan interface{}
 }
 
-func (t *testingConnection) ConnectionId() string {
+func (t *testingConnection) ConnectionID() string {
 	return "test"
 }
 
@@ -75,10 +75,10 @@ func (t *testingConnection) clientReceive() (string, error) {
 	for {
 		if message, err := buf.ReadString(30); err != nil {
 			buf.Write(data[:n])
-			if n, err = t.cliReader.Read(data); err != nil {
-				return "", err
-			} else {
+			if n, err = t.cliReader.Read(data); err == nil {
 				buf.Write(data[:n])
+			} else{
+				return "", err
 			}
 		} else {
 			return message[:len(message)-1], nil

--- a/signalr-go-server/pkg/signalr/testingconnection_test.go
+++ b/signalr-go-server/pkg/signalr/testingconnection_test.go
@@ -43,7 +43,7 @@ func newTestingConnection() *testingConnection {
 			ginkgo.Fail(fmt.Sprint(err))
 		}
 	}()
-	conn.received = make(chan interface{}, 20)
+	conn.received = make(chan interface{}, 0)
 	go func() {
 		for {
 			if message, err := conn.clientReceive(); err == nil {

--- a/signalr-go-server/pkg/signalr/websocketServer.go
+++ b/signalr-go-server/pkg/signalr/websocketServer.go
@@ -12,7 +12,7 @@ import (
 // MapHub used to register a SignalR Hub with the specified ServeMux
 func MapHub(mux *http.ServeMux, path string, hub HubInterface) {
 	mux.HandleFunc(fmt.Sprintf("%s/negotiate", path), negotiateHandler)
-	server := NewServer(hub)
+	server := newServer(hub)
 	mux.Handle(path, websocket.Handler(func(ws *websocket.Conn) {
 		connectionID := ws.Request().URL.Query().Get("id")
 		if len(connectionID) == 0 {

--- a/signalr-go-server/pkg/signalr/websocketServer.go
+++ b/signalr-go-server/pkg/signalr/websocketServer.go
@@ -41,11 +41,15 @@ func negotiateHandler(w http.ResponseWriter, req *http.Request) {
 		},
 	}
 
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		fmt.Println(err)
+	}
 }
 
 func getConnectionID() string {
 	bytes := make([]byte, 16)
-	rand.Read(bytes)
+	if _, err := rand.Read(bytes); err != nil {
+		fmt.Println(err)
+	}
 	return base64.StdEncoding.EncodeToString(bytes)
 }

--- a/signalr-go-server/pkg/signalr/websocketconnection.go
+++ b/signalr-go-server/pkg/signalr/websocketconnection.go
@@ -11,7 +11,7 @@ type webSocketConnection struct {
 	connectionID string
 }
 
-func (w *webSocketConnection) ConnectionId() string {
+func (w *webSocketConnection) ConnectionID() string {
 	return w.connectionID
 }
 
@@ -24,11 +24,9 @@ func (w *webSocketConnection) Read(p []byte) (n int, err error) {
 		var data []byte
 		if err = websocket.Message.Receive(w.ws, &data); err != nil {
 			return 0, err
-		} else {
-			w.r = bytes.NewReader(data)
-			return w.r.Read(p)
 		}
-	} else {
+		w.r = bytes.NewReader(data)
 		return w.r.Read(p)
 	}
+	return w.r.Read(p)
 }


### PR DESCRIPTION
new: Connection.SetTimeout()/Timeout()
new: Hub/HubContext.Items()
new: Caller-Support
new: Abort-Support
new: Server options for Hub creation strategy
new: Server options for ClientTimeoutInterval, HandshakeTimeout, KeepAliveInterval, EnableDetailedErrors, StreamBufferCapacity, MaximumReceiveMessageSize (untested), HubChanReceiveTimeout, Logger
new: BDD tests for all that
new: Context for cancellation (not tested yet)
chg: Various golint / golangci-lint / go test -race findings
chg: Server/serverloop: Refactoring
chg: Ping: Moved to serverLoop for better KeepAliveWatchDog implementation

